### PR TITLE
Fixed camera_calibration parameter and changed default frames to rgb instead of depth

### DIFF
--- a/include/skeleton_tracker/xtion_tracker.hpp
+++ b/include/skeleton_tracker/xtion_tracker.hpp
@@ -274,7 +274,7 @@ public:
     sub = nh_.subscribe("/image_calib", 1000, chatterCallback);
 
     // read yaml files
-    std::ifstream fin("/home/lucie02/.ros/camera_info/rgb_PS1080_PrimeSense.yaml");
+    std::ifstream fin(camera_calibration.c_str());
     if (fin.good())
     {
         YAML_0_3::Parser parser(fin);

--- a/launch/tracker.launch
+++ b/launch/tracker.launch
@@ -3,8 +3,8 @@
   <arg name="machine" default="localhost" />
   <arg name="user" default="" />
   <arg name="camera" default="head_xtion" />
-  <arg name="rgb_frame_id"   default="$(arg camera)_depth_optical_frame" />
-  <arg name="depth_frame_id" default="$(arg camera)_depth_optical_frame" />
+  <arg name="rgb_frame_id"   default="$(arg camera)_rgb_optical_frame" />
+  <arg name="depth_frame_id" default="$(arg camera)_rgb_optical_frame" />
   <arg name="camera_calibration" default="~/.ros/camera_info/rgb_PS1080_PrimeSense.yaml" />
 
 


### PR DESCRIPTION
The change from `*depth_optical_frame` to `*rgb_optical_frame` assumes that we're using `depth_registered:=true`, which I think we do, at least `depth_registration` is set to true for the driver. @OMARI1988 